### PR TITLE
Chat mobile : save and query messages

### DIFF
--- a/src/models/Message.ts
+++ b/src/models/Message.ts
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+export interface IMessage extends mongoose.Document {
+  text: string;
+  userId: string;
+  username: string;
+  createdAt: Date;
+  updatedAt?: Date;
+}
+
+const MessageSchema = new mongoose.Schema(
+  {
+    text: {
+      type: mongoose.SchemaTypes.String,
+      required: true,
+    },
+    userId: {
+      type: mongoose.SchemaTypes.String,
+      required: true,
+    },
+    username: {
+      type: mongoose.SchemaTypes.String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+export default mongoose.model<IMessage>('Message', MessageSchema);

--- a/src/resolvers/chat.ts
+++ b/src/resolvers/chat.ts
@@ -1,4 +1,4 @@
-import MessageModel from '../models/Message';
+import MessageModel, { IMessage } from '../models/Message';
 import { PubSub } from 'apollo-server-express';
 const pubsub = new PubSub();
 
@@ -18,6 +18,13 @@ export const chatMutation = {
     const message = await new MessageModel({ text, userId, username }).save();
     pubsub.publish('NEW_MESSAGE', { chatFeed: message });
     return message;
+  },
+};
+
+export const chatQuery = {
+  messages: async (): Promise<IMessage[]> => {
+    const messages = await MessageModel.find({});
+    return messages;
   },
 };
 

--- a/src/resolvers/chat.ts
+++ b/src/resolvers/chat.ts
@@ -1,3 +1,4 @@
+import MessageModel from '../models/Message';
 import { PubSub } from 'apollo-server-express';
 const pubsub = new PubSub();
 
@@ -10,17 +11,11 @@ export const chatSubscription = {
 };
 
 export const chatMutation = {
-  newMessage: (
+  newMessage: async (
     _: unknown,
     { text, userId, username }: IMessageInput
-  ): IMessageOutput => {
-    const date = new Date();
-    const message = {
-      text,
-      userId,
-      username,
-      date,
-    };
+  ): Promise<IMessageOutput> => {
+    const message = await new MessageModel({ text, userId, username }).save();
     pubsub.publish('NEW_MESSAGE', { chatFeed: message });
     return message;
   },
@@ -33,5 +28,5 @@ interface IMessageInput {
 }
 
 interface IMessageOutput extends IMessageInput {
-  date: Date;
+  createdAt: Date;
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,13 +1,14 @@
 import { userQuery, userMutation } from './user';
 import { topicQuery, topicMutation } from './forum/topic';
 import { AuthQuery, AuthMutation } from './auth';
-import { chatSubscription, chatMutation } from './chat';
+import { chatSubscription, chatMutation, chatQuery } from './chat';
 
 export default {
   Query: {
     ...userQuery,
     ...topicQuery,
     ...AuthQuery,
+    ...chatQuery,
   },
   Mutation: {
     ...userMutation,

--- a/src/typeDefs/chat.ts
+++ b/src/typeDefs/chat.ts
@@ -5,7 +5,7 @@ export default gql`
     text: String!
     userId: String!
     username: String!
-    date: String!
+    createdAt: String!
   }
 
   extend type Mutation {

--- a/src/typeDefs/chat.ts
+++ b/src/typeDefs/chat.ts
@@ -16,6 +16,10 @@ export default gql`
     ): IMessageOutput
   }
 
+  extend type Query {
+    messages: [IMessageOutput]
+  }
+
   extend type Subscription {
     chatFeed: IMessageOutput
   }


### PR DESCRIPTION
* The _date_ subfield changed to _createdAt_
* When using the _newMessage_ mutation, message is saved to db

## Message query :
```gql
query {
  messages {
     text
     userId
     username
     createdAt
  }
}