### PR TITLE
User related forum (like/dislike topics and comments)

### DIFF
--- a/src/middlewares/authenticateRequest.ts
+++ b/src/middlewares/authenticateRequest.ts
@@ -25,7 +25,7 @@ export default async ({ res, req, connection }: {
   } else {
     try {
       const token = req?.get('Authorization')?.split(' ')[1] || '';
-      if(!token) throw new Error("no token")
+      if(!token) throw new Error("no authorization token")
       const decodedToken: any = jwt.verify(token, process.env.JWT_SECRET);
       if(!decodedToken.userID) throw new Error("Token not valid")
       await UserModel.findByIdAndUpdate(decodedToken?.userID, {

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -9,6 +9,8 @@ export interface IComment extends mongoose.Document {
   dislike: number;
   createdAt: Date;
   updatedAt?: Date;
+  votersIdLikes: string[];
+  votersIdDislikes: string[];
 }
 export interface ICommentUpdates extends mongoose.Document {
   authorID: string;
@@ -19,6 +21,24 @@ export interface ICommentUpdates extends mongoose.Document {
   dislike?: number;
   updatedAt: Date;
   commentId: string;
+  votersIdLikes: string[];
+  votersIdDislikes: string[];
+  voteType: string;
+}
+
+export interface ILikeDislike extends mongoose.Document {
+  authorID: string;
+  topicId?: string;
+  author?: string;
+  commentBody?: string;
+  like?: number;
+  dislike?: number;
+  updatedAt: Date;
+  commentId: string;
+  voterID: string;
+  votersIdLikes: string[];
+  votersIdDislikes: string[];
+  voteType: string;
 }
 
 const CommentModel = new mongoose.Schema(
@@ -49,6 +69,16 @@ const CommentModel = new mongoose.Schema(
       type: mongoose.SchemaTypes.Number,
       required: false,
     },
+    votersIdLikes: [{
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: false,
+    }],  
+    votersIdDislikes: [{
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: false,
+    }]
   },
   {
     timestamps: true,

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -23,11 +23,11 @@ export interface ICommentUpdates extends mongoose.Document {
 
 const CommentModel = new mongoose.Schema(
   {
-    // authorId: {
-    //   type: mongoose.Schema.Types.ObjectId,
-    //   ref: 'User',
-    //   required: true,
-    // },
+    authorID: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
     topicId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Topic',

--- a/src/models/Topic.ts
+++ b/src/models/Topic.ts
@@ -10,6 +10,7 @@ export interface ITopic extends mongoose.Document {
   url: [string];
   tags: [string];
   comments: Array<IComment>;
+  likes: [string];
 }
 export interface ITopicUpdates extends mongoose.Document {
   _id: string;
@@ -21,6 +22,11 @@ export interface ITopicUpdates extends mongoose.Document {
   lastUpdateDate?: Date;
   createdAt: Date;
   updatedAt?: Date;
+}
+
+export interface ILikeTopic extends mongoose.Document {
+  userID: string;
+  topicID: string;
 }
 
 const TopicModel = new mongoose.Schema(
@@ -49,8 +55,8 @@ const TopicModel = new mongoose.Schema(
         ref: 'Comment',
       },
     ],
-    like: {
-      type: mongoose.SchemaTypes.Number,
+    likes: {
+      type: [mongoose.SchemaTypes.ObjectId],
     },
     dislike: {
       type: mongoose.SchemaTypes.Number,

--- a/src/resolvers/forum/topic.ts
+++ b/src/resolvers/forum/topic.ts
@@ -1,5 +1,5 @@
 import TopicModel, { ITopic, ITopicUpdates } from '../../models/Topic';
-import CommentModel, { IComment, ICommentUpdates } from '../../models/Comment';
+import CommentModel, { IComment, ICommentUpdates, ILikeDislike } from '../../models/Comment';
 import { AuthContext } from '../../middlewares/authenticateRequest'
 
 export const topicQuery = {
@@ -75,12 +75,24 @@ export const topicMutation = {
     _: unknown,
     commentUpdates: ICommentUpdates
   ): Promise<IComment | null> => {
-    const result = await CommentModel.findByIdAndUpdate(
-      { _id: commentUpdates.commentId },
-      { $set: commentUpdates },
-      { new: true }
-    );
-    return result;
+    const { commentId, voteType } = commentUpdates;
+    const comment = await CommentModel.findOne({_id: commentId});
+    
+    if (comment) {
+      const { votersIdLikes, votersIdDislikes} = comment;
+      let updatedComment = { ...commentUpdates, votersIdLikes, votersIdDislikes };
+
+      const result = await CommentModel.findByIdAndUpdate(
+        { _id: commentId },
+        { $set: commentUpdates },
+        { new: true }
+      );
+      console.log(result)
+      return result;
+      
+    } else {
+      return null;
+    }
   },
 
   deleteComment: async (
@@ -89,4 +101,86 @@ export const topicMutation = {
   ): Promise<IComment | null> => {
     return await CommentModel.findOneAndDelete({ _id: commentId });
   },
-};
+
+  likeComment: async (
+    _: unknown,
+    commentUpdates: ILikeDislike
+  ): Promise<IComment | null> => {
+    const { commentId, voterID, voteType } = commentUpdates;
+    const comment = await CommentModel.findOne({_id: commentId});
+    let updatedComment;
+    
+    if (comment) {
+      let votersIdLikes = comment.votersIdLikes;
+      let votersIdDislikes = comment.votersIdDislikes;
+
+      // if user didn't already liked or disliked the comment
+      if (!votersIdLikes.includes(voterID) && !votersIdDislikes.includes(voterID)) {
+        votersIdLikes.push(voterID); // adds user id in the comment's "likes" array
+
+      // else if user already liked the comment
+      } else if (votersIdLikes.includes(voterID)) {
+        const index = votersIdLikes.indexOf(voterID);
+        votersIdLikes.splice(index); // removes user id from the comment's "likes" array
+        
+      // else if user already disliked the comment
+      } else if (votersIdDislikes.includes(voterID)) {
+        votersIdLikes.push(voterID); // adds user id in the comment's "dislikes" array
+        const index = votersIdDislikes.indexOf(voterID);
+        votersIdDislikes.splice(index); // removes user id from the comment's "dislikes" array
+      }
+
+      updatedComment = { ...commentUpdates, votersIdDislikes, votersIdLikes };
+      const result = await CommentModel.findByIdAndUpdate(
+        { _id: commentId },
+        { $set: updatedComment },
+        { new: true }
+      );
+      return result;
+      
+    } else {
+      return null;
+    }
+  },
+
+  dislikeComment: async (
+    _: unknown,
+    commentUpdates: ILikeDislike
+  ): Promise<IComment | null> => {
+    const { commentId, voterID, voteType } = commentUpdates;
+    const comment = await CommentModel.findOne({_id: commentId});
+    let updatedComment;
+    
+    if (comment) {
+      let votersIdLikes = comment.votersIdLikes;
+      let votersIdDislikes = comment.votersIdDislikes;
+      
+      // if user didn't already liked or disliked the comment
+      if (!votersIdDislikes.includes(voterID) && !votersIdLikes.includes(voterID)) {
+        votersIdDislikes.push(voterID); // adds user id in the comment's "dislikes" array
+        
+        // else if user already disliked the comment
+      } else if (votersIdDislikes.includes(voterID)) {
+        const index = votersIdDislikes.indexOf(voterID);
+        votersIdDislikes.splice(index); // // removes user id from the comment's "dislikes" array
+        
+        // else if user already liked the comment
+      } else if (votersIdLikes.includes(voterID)) {
+        votersIdDislikes.push(voterID); //add user id the the comment's "dislikes" array
+        const index = votersIdLikes.indexOf(voterID);
+        votersIdLikes.splice(index); // removes user id from the comment's dislikes array
+      }
+
+      updatedComment = { ...commentUpdates, votersIdDislikes, votersIdLikes };
+      const result = await CommentModel.findByIdAndUpdate(
+        { _id: commentId },
+        { $set: updatedComment },
+        { new: true }
+      );
+      return result;
+      
+    } else {
+      return null;
+    }
+  },
+}

--- a/src/resolvers/forum/topic.ts
+++ b/src/resolvers/forum/topic.ts
@@ -1,4 +1,4 @@
-import TopicModel, { ITopic, ITopicUpdates } from '../../models/Topic';
+import TopicModel, { ITopic, ITopicUpdates, ILikeTopic } from '../../models/Topic';
 import CommentModel, { IComment, ICommentUpdates, ILikeDislike } from '../../models/Comment';
 import { AuthContext } from '../../middlewares/authenticateRequest'
 
@@ -48,6 +48,67 @@ export const topicMutation = {
     );
     return topic;
   },
+
+  handleLikeTopic: async (
+    _: unknown,
+    { topicID, userID }: ILikeTopic
+  ): Promise<number | null> => {
+    try {
+      const topic = await TopicModel.findOne({ _id: topicID });
+      
+      if (topic) { 
+        const userIdIndex = topic.likes.indexOf(userID);
+        console.log(topic.likes.indexOf(userID))
+        
+        // if user didnt already liked topic
+        if (userIdIndex === -1) {
+          const likes = topic.likes;
+          likes.push(userID);
+          console.log(likes);
+  
+          try {
+            const newTopic = await TopicModel.findOneAndUpdate(
+              { _id: topicID },
+              { $set: { likes } },
+              { new: true }
+            );
+            
+            if (newTopic) return newTopic.likes.length;
+            else return null;
+          } catch(e) {
+            console.log(e);
+            return null;
+          }
+        // if user already liked topic
+        } else {
+          const likes = topic.likes;
+          likes.splice(userIdIndex);
+          console.log(likes);
+
+
+          try {
+            const newTopic = await TopicModel.findOneAndUpdate(
+              { _id: topicID },
+              { $set: { likes } },
+              { new: true }
+            );
+            
+            if (newTopic) return newTopic.likes.length;
+            else return null;
+          } catch(e) {
+            console.log(e);
+            return null;
+          }
+        }
+      } else {
+        return null;
+      }
+    } catch(e) {
+      console.log(e);
+      return null;
+    }
+  },
+  
 
   deleteTopic: async (_: unknown, topicId: string): Promise<ITopic | null> => {
     const topic = TopicModel.findOneAndDelete({ _id: topicId });

--- a/src/resolvers/forum/topic.ts
+++ b/src/resolvers/forum/topic.ts
@@ -75,7 +75,6 @@ export const topicMutation = {
     _: unknown,
     commentUpdates: ICommentUpdates
   ): Promise<IComment | null> => {
-    console.log(commentUpdates);
     const result = await CommentModel.findByIdAndUpdate(
       { _id: commentUpdates.commentId },
       { $set: commentUpdates },

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -45,6 +45,9 @@ export const userMutation = {
       userID: user._id,
       token: createAccessToken(user),
       tokenExpiration,
+      firstname,
+      lastname,
+      role,
     };
   },
 };

--- a/src/typeDefs/topic.ts
+++ b/src/typeDefs/topic.ts
@@ -10,7 +10,7 @@ export default gql`
     url: [String]
     tags: [String]
     comments: [Comment]
-    like: Int
+    likes: [ID]
     dislike: Int
     createdAt: Float
     updatedAt: Float
@@ -56,6 +56,11 @@ export default gql`
       dislike: Int
       updatedAt: Float
     ): Topic
+
+    handleLikeTopic(
+      userID: ID!
+      topicID: ID!
+    ): Int
 
     deleteTopic(_id: ID!): Topic
 

--- a/src/typeDefs/topic.ts
+++ b/src/typeDefs/topic.ts
@@ -26,6 +26,8 @@ export default gql`
     dislike: Int
     createdAt: Float
     updatedAt: Float
+    votersIdLikes: [ID]
+    votersIdDislikes: [ID]
   }
 
   extend type Query {
@@ -67,9 +69,30 @@ export default gql`
     updateComment(
       commentId: ID!
       commentBody: String
-      like: Int
-      dislike: Int
       updatedAt: Float
+      votersIdLike: ID
+      votersIdDislike: ID
+      voteType: String
+    ): Comment
+
+    likeComment(
+      commentId: ID!
+      commentBody: String
+      updatedAt: Float
+      votersIdLike: ID
+      votersIdDislike: ID
+      voteType: String
+      voterID: ID
+    ): Comment
+
+    dislikeComment(
+      commentId: ID!
+      commentBody: String
+      updatedAt: Float
+      votersIdLike: ID
+      votersIdDislike: ID
+      voteType: String
+      voterID: ID
     ): Comment
 
     deleteComment(_id: ID!): Comment


### PR DESCRIPTION
## Liking a Topic

- Added logic to save the likes of a Topic
- Likes are stored as an array of user IDs (the IDs of the users who likes the Topic)
- If user already liked the topic and sends a like request, his ID is removed from the Topic's likes array

## Liking/disliking a Comment
Same logic as the Topic above, except :

- Added logic to save the likes **and the dislike**s of a Comment
- If user already liked a Comment and dislikes it, his id is removed from the likes array (and vice versa)